### PR TITLE
Add autoname to namespace classes

### DIFF
--- a/class_only_design/__init__.py
+++ b/class_only_design/__init__.py
@@ -7,5 +7,6 @@ __email__ = "foreverwintr@gmail.com"
 __version__ = "0.2.0"
 
 from class_only_design.api import ClassOnly
-from class_only_design.api import constant
 from class_only_design.api import Namespace
+from class_only_design.api import constant
+from class_only_design.constants import autoname

--- a/class_only_design/api.py
+++ b/class_only_design/api.py
@@ -10,10 +10,12 @@ class ClassOnly(metaclass=OnlyMeta):
     ClassOnly classes disallow instantiation or state change.
     """
 
+
 class Namespace(metaclass=MetaNamespace):
     """
     Namespace classes are intended for storing symbolic constants.
     """
+
 
 class constant:
     """

--- a/class_only_design/constants.py
+++ b/class_only_design/constants.py
@@ -1,3 +1,5 @@
 
 # These names are reserved for use by the namespace class machinery. They cannot appear in namespace classes.
 RESERVED_NAMES = {"nameof"}
+
+autoname = object()

--- a/class_only_design/meta.py
+++ b/class_only_design/meta.py
@@ -64,3 +64,7 @@ class MetaNamespace(OnlyMeta):
                     if not util._is_internal(k) and k not in seen_attrs:
                         seen_attrs.add(k)
                         yield v
+
+    @classmethod
+    def __prepare__(metacls, name, bases, **kwds):
+        return util.NamespaceLoader()

--- a/class_only_design/tests/test_namespace.py
+++ b/class_only_design/tests/test_namespace.py
@@ -4,6 +4,7 @@ import sys
 from class_only_design import Namespace
 from class_only_design import constant
 from class_only_design import constants
+from class_only_design import autoname
 
 iterable_compare = list
 # In python < 3.6, classes aren't ordered
@@ -192,3 +193,12 @@ class InheritanceTests(unittest.TestCase):
 
         self.assertEqual(X3.x, 1)
         self.assertEqual(X4.y, 2)
+
+    def test_auto_name(self):
+        class A(Namespace):
+            attr = autoname
+            other = autoname
+
+        self.assertEqual(A.attr, 'attr')
+        self.assertEqual(A.other, 'other')
+        self.assertEqual(A.nameof.attr, 'attr')

--- a/class_only_design/util.py
+++ b/class_only_design/util.py
@@ -49,3 +49,10 @@ class KeyGetter:
 
     def __dir__(self):
         return sorted(vars(self._cls_))
+
+
+class NamespaceLoader(dict):
+    def __setitem__(self, k, v):
+        if v is constants.autoname:
+            return super().__setitem__(k, k)
+        return super().__setitem__(k, v)


### PR DESCRIPTION
This adds autoname to namespace. The test is illustrative:

```python
from class_only_design import Namespace
from class_only_design import autoname

class A(Namespace):
    attr = autoname
    other = autoname

self.assertEqual(A.attr, 'attr')
self.assertEqual(A.other, 'other')
```

